### PR TITLE
Fix: Correct field name

### DIFF
--- a/proxy/v2/main.go
+++ b/proxy/v2/main.go
@@ -10,7 +10,7 @@ import (
 
 const socks5Ver = 0x05
 const cmdBind = 0x01
-const atypIPV4 = 0x01
+const atypeIPV4 = 0x01
 const atypeHOST = 0x03
 const atypeIPV6 = 0x04
 

--- a/proxy/v3/main.go
+++ b/proxy/v3/main.go
@@ -112,7 +112,7 @@ func connect(reader *bufio.Reader, conn net.Conn) (err error) {
 		return fmt.Errorf("not supported ver:%v", ver)
 	}
 	if cmd != cmdBind {
-		return fmt.Errorf("not supported cmd:%v", ver)
+		return fmt.Errorf("not supported cmd:%v", cmd)
 	}
 	addr := ""
 	switch atyp {

--- a/proxy/v3/main.go
+++ b/proxy/v3/main.go
@@ -12,7 +12,7 @@ import (
 
 const socks5Ver = 0x05
 const cmdBind = 0x01
-const atypIPV4 = 0x01
+const atypeIPV4 = 0x01
 const atypeHOST = 0x03
 const atypeIPV6 = 0x04
 
@@ -116,7 +116,7 @@ func connect(reader *bufio.Reader, conn net.Conn) (err error) {
 	}
 	addr := ""
 	switch atyp {
-	case atypIPV4:
+	case atypeIPV4:
 		_, err = io.ReadFull(reader, buf)
 		if err != nil {
 			return fmt.Errorf("read atyp failed:%w", err)

--- a/proxy/v4/main.go
+++ b/proxy/v4/main.go
@@ -13,7 +13,7 @@ import (
 
 const socks5Ver = 0x05
 const cmdBind = 0x01
-const atypIPV4 = 0x01
+const atypeIPV4 = 0x01
 const atypeHOST = 0x03
 const atypeIPV6 = 0x04
 
@@ -117,7 +117,7 @@ func connect(reader *bufio.Reader, conn net.Conn) (err error) {
 	}
 	addr := ""
 	switch atyp {
-	case atypIPV4:
+	case atypeIPV4:
 		_, err = io.ReadFull(reader, buf)
 		if err != nil {
 			return fmt.Errorf("read atyp failed:%w", err)

--- a/proxy/v4/main.go
+++ b/proxy/v4/main.go
@@ -113,7 +113,7 @@ func connect(reader *bufio.Reader, conn net.Conn) (err error) {
 		return fmt.Errorf("not supported ver:%v", ver)
 	}
 	if cmd != cmdBind {
-		return fmt.Errorf("not supported cmd:%v", ver)
+		return fmt.Errorf("not supported cmd:%v", cmd)
 	}
 	addr := ""
 	switch atyp {


### PR DESCRIPTION
Hello, ke chun. I found the fields error when i learn to your course.   
Such as `atypeIPV6` is correct. But the `atypIPV4` is different to another. 
To make sure the fields are consistent, so i create this PR.
I appreciate the course you taught. :)

